### PR TITLE
s/tostring/tobytes

### DIFF
--- a/PlatformWithOS/demo/EPD.py
+++ b/PlatformWithOS/demo/EPD.py
@@ -130,7 +130,7 @@ to use:
             raise EPDError('image size mismatch')
 
         with open(os.path.join(self._epd_path, 'LE', 'display_inverse'), 'r+b') as f:
-            f.write(image.tostring())
+            f.write(image.tobytes())
 
         if self.auto:
             self.update()


### PR DESCRIPTION
See [Pil.Image.Image.tobytes](http://pillow.readthedocs.io/en/3.0.x/reference/Image.html?highlight=tobytes#PIL.Image.Image.tobytes) - not sure if using Pillow 3 is the "default" or not, but just in case here's a PR so the demos will work for people using Pillow 3.